### PR TITLE
Fix errors and sync code terminology with openage docs

### DIFF
--- a/include/genie/file/ISerializable.h
+++ b/include/genie/file/ISerializable.h
@@ -435,16 +435,12 @@ protected:
     {
         switch (getOperation()) {
         case OP_WRITE:
-            for (typename std::array<T, N>::const_iterator it = vec.cbegin(); it != vec.cend(); ++it) {
-                write<T>(*it);
-            }
+            ostr_->write(reinterpret_cast<const char *const>(vec.data()), sizeof(T) *  N);
 
             break;
 
         case OP_READ:
-            for (size_t i = 0; i < N; ++i) {
-                vec[i] = read<T>();
-            }
+            istr_->read(reinterpret_cast<char *>(vec.data()), sizeof(T) * N);
 
             break;
 
@@ -496,19 +492,12 @@ protected:
             if (vec.size() != size) {
                 std::cerr << "Warning!: vector size differs len!" << vec.size() << " " << size << std::endl;
             }
-
-            for (typename std::vector<T>::iterator it = vec.begin(); it != vec.end(); ++it) {
-                write<T>(*it);
-            }
-
+            ostr_->write(reinterpret_cast<const char *const>(vec.data()), sizeof(T) * std::min(size, vec.size()));
             break;
 
         case OP_READ:
             vec.resize(size);
-
-            for (size_t i = 0; i < size; ++i) {
-                vec[i] = read<T>();
-            }
+            istr_->read(reinterpret_cast<char *>(vec.data()), sizeof(T) * size);
 
             break;
 

--- a/include/genie/file/ISerializable.h
+++ b/include/genie/file/ISerializable.h
@@ -224,7 +224,9 @@ protected:
     ///
     /// @return read data
     //
-    template <typename T>
+    template <typename T,
+              std::enable_if_t<std::is_pod<T>::value, int> = 0
+              >
     T read()
     {
         T ret = {};
@@ -241,7 +243,9 @@ protected:
     ///
     /// @param data to write.
     //
-    template <typename T>
+    template <typename T,
+              std::enable_if_t<std::is_pod<T>::value, int> = 0
+              >
     void write(const T &data)
     {
         ostr_->write(reinterpret_cast<const char *>(&data), sizeof(T));
@@ -250,7 +254,9 @@ protected:
     //----------------------------------------------------------------------------
     /// Generic read method for arrays. It allocates new space if pointer is 0.
     //
-    template <typename T>
+    template <typename T,
+              std::enable_if_t<std::is_pod<T>::value, int> = 0
+              >
     void read(T **array, size_t len)
     {
         if (!istr_->eof()) {
@@ -265,7 +271,9 @@ protected:
     //----------------------------------------------------------------------------
     /// Writes an array to file.
     //
-    template <typename T>
+    template <typename T,
+              std::enable_if_t<std::is_pod<T>::value, int> = 0
+              >
     void write(const T *const *data, size_t len)
     {
         ostr_->write(reinterpret_cast<const char *const>(*data), sizeof(T) * len);

--- a/include/genie/resource/SmpFile.h
+++ b/include/genie/resource/SmpFile.h
@@ -41,40 +41,36 @@ private:
     /// Always SMPX
     std::array<uint8_t, 4> m_header = {'S', 'M', 'P', '$' };
 
-    /// possibly version
+    /// Version
     /// Ex: 256, 0x00000100 (same value for almost all units)
-    int32_t m_version2 = 0;
+    int32_t m_version = 0;
 
     /// Number of frames
     /// Ex: 721, 0x000002D1
     int32_t m_numFrames = 0;
 
-    /// File size SMX (this file)
-    /// Ex: 2706603, 0x000294CAB (size without header)
-    uint32_t m_size = 0;
-
-    /// ??
+    /// Number of facets
     /// 1, 0x0000001 (almost always 0x00000001)
-    int32_t m_unknown;
+    int32_t m_facetNum;
 
-    /// Number of frames
+    /// Number of frames per facet
     /// 721, 0x000002D1 (0x00000001 for version 0x0B)
-    int32_t m_numFrames2;
+    int32_t m_framesPerFacet;
 
-    ///  possibly checksum
+    /// Checksum
     /// 0x8554F6F3
     int32_t m_checksum;
 
     /// File size in bytes
     /// Ex:  0x003D5800
-    int32_t m_byteCount;
+    int32_t m_size;
 
-    /// Actually used version?
-    /// 0x0B or 0x0C
-    int32_t m_version;
+    /// Source format
+    /// 0x0B (SLP) or 0x0C (PSD)
+    int32_t m_source_format;
 
     /// Comment
-    /// Always empty, 32 bytes
+    /// 32 bytes
     std::string m_comment;
 
     std::vector<SmpFrame> m_frames;

--- a/include/genie/resource/SmpFrame.h
+++ b/include/genie/resource/SmpFrame.h
@@ -13,13 +13,13 @@ struct SmpPixel
 {
     uint8_t index; /// Normal palette index
     uint8_t section; /// Need to look up in palette.conf to find the correct color table
-    uint8_t damageMask; /// When units get damaged
-    uint8_t damageMask2; /// When units get damaged 2
+    uint8_t damageModifier; /// When units get damaged
+    uint8_t damageModifier2; /// When units get damaged 2
 
     inline uint8_t paletteIndex() const noexcept { return section >> 2; }
     inline uint8_t paletteSection() const noexcept { return section & 0b11; }
-    inline bool isMasked1() const noexcept { return damageMask & 0x80; }
-    inline bool isMasked2() const noexcept { return damageMask & 3; }
+    inline bool isMasked1() const noexcept { return damageModifier & 0x80; }
+    inline bool isMasked2() const noexcept { return damageModifier & 3; }
 }
 #ifndef _MSC_VER
 __attribute__((packed));
@@ -60,15 +60,15 @@ private:
     int32_t hotspot_x = 0;
     int32_t hotspot_y = 0;
 
-    uint32_t m_frameType = 0;
+    uint32_t m_layerType = 0;
 
     std::vector<uint16_t> left_edges_;
     std::vector<uint16_t> right_edges_;
 
-    uint32_t properties_;
+    uint32_t flags_;
     uint32_t cmd_table_offset_;
     uint32_t outline_table_offset_;
-    std::streampos slp_file_pos_;
+    std::streampos smp_file_pos_;
 };
 
 }//namespace genie

--- a/include/genie/resource/SmxFile.h
+++ b/include/genie/resource/SmxFile.h
@@ -45,7 +45,7 @@ private:
     /// Always SMPX
     std::array<uint8_t, 4> m_header = {'S', 'M', 'P', 'X' };
 
-    /// probably version
+    /// Version
     /// 2, 0x0002 (for almost all units, some have 0x0001)
     uint16_t m_version = 0;
 

--- a/include/genie/resource/SmxFrame.h
+++ b/include/genie/resource/SmxFrame.h
@@ -12,11 +12,11 @@ namespace genie {
 /**
  * @brief The SmxFrame class
  * The frame definitions start directly after the file header.
- * Like in the SMP format, the frames come in bundles that consist of up to 3 images:
- *  - main sprite
- *  - shadow for that sprite (optional)
- *  - outline (optional)
- * Which of these images are present in a bundle is determined by the value bundle_type from the bundle header.
+ * Like in the SMP format, the frames have up to 3 images:
+ *  - main layer
+ *  - shadow layer (optional)
+ *  - outline layer (optional)
+ * Which of these layeers are present in a frame is determined by the value frame_type from the frame header.
  */
 class SmxFrame : public ISerializable
 {
@@ -50,7 +50,7 @@ protected:
     void serializeObject() override;
 
 private:
-    struct FrameHeader {
+    struct LayerHeader {
         uint16_t width = 0; /// Width of image
         uint16_t height = 0; /// Height of image
 
@@ -69,14 +69,14 @@ private:
                 serialize(padRight);
             }
         };
-        /// Directly after the frame header, an array of smp_frame_row_edge (of length height) structs begins. These work exactly like the row edges in the SMP files.
+        /// Directly after the layer header, an array of smp_layer_row_edge (of length height) structs begins. These work exactly like the row edges in the SMP files.
         std::vector<RowEdge> rowEdges;
     };
-    void serializeFrameHeader(FrameHeader &header);
+    void serializeLayerHeader(LayerHeader &header);
 
-    void readNormalGraphics();
-    void readShadowGraphics();
-    void readOutlineGraphics();
+    void readNormalLayer();
+    void readShadowLayer();
+    void readOutlineLayer();
 
     std::vector<SmpPixel> decode4Plus1(const std::vector<uint8_t> &data);
     std::vector<SmpPixel> decode8To5(const std::vector<uint8_t> &data);
@@ -93,8 +93,8 @@ private:
         EndOfRow = 0b11
     };
 
-    /// SMX Bundle header
-    struct BundleHeader {
+    /// SMX Frame header
+    struct FrameHeader {
         enum TypeBits : uint8_t {
             Unused1 = 1 << 7,
             Unused2 = 1 << 6,
@@ -105,31 +105,31 @@ private:
 
             /// Determines the compression algorithm for the main graphic frame.
             /// 0 = 4plus1; 1 = 8to5 (see the Compression Algorithms section)
-            HasDamageMask = 1 << 3,
+            HasDamageModifier = 1 << 3,
 
             /// If set to 1, the bundle contains an outline frame
-            OutlineFrame = 1 << 2,
+            OutlineLayer = 1 << 2,
 
             /// If set to 1, the bundle contains a shadow frame
-            ShadowFrame = 1 << 1,
+            ShadowLayer = 1 << 1,
 
             /// If set to 1, the bundle contains a main graphic frame
-            NormalFrame = 1 << 0
+            NormalLayer = 1 << 0
         };
 
-        /// Bundle Type
-        /// bundle_type is a bit field. This means that every bit set to 1 in this values tells us something about the bundle.
-        uint8_t type = 0;
+        /// Frame Type
+        /// frame_type is a bit field. This means that every bit set to 1 in this values tells us something about the bundle.
+        uint8_t frameType = 0;
 
         /// Palette number
         uint8_t palette = 0;
         /// possibly uncompressed size
-        uint32_t maybeSize = 0;
-    } m_bundleHeader;
+        uint32_t size = 0;
+    } m_frameHeader;
 
-    FrameHeader m_normalHeader;
-    FrameHeader m_shadowHeader;
-    FrameHeader m_outlineHeader;
+    LayerHeader m_normalHeader;
+    LayerHeader m_shadowHeader;
+    LayerHeader m_outlineHeader;
 };
 
 typedef std::shared_ptr<SmxFrame> SmxFramePtr;

--- a/include/genie/resource/WavFile.h
+++ b/include/genie/resource/WavFile.h
@@ -16,13 +16,13 @@ public:
 
     struct WavHeader {
         // RIFF header
-        uint32_t ChunkID{};
-        uint32_t ChunkSize{};
-        uint32_t Format{};
+        uint32_t ChunkID;
+        uint32_t ChunkSize;
+        uint32_t Format;
 
         // fmt subchunk
-        uint32_t Subchunk1ID{};
-        uint32_t Subchunk1Size{};
+        uint32_t Subchunk1ID;
+        uint32_t Subchunk1Size;
 
         enum AudioFormats {
             PCM = 0x1,
@@ -32,17 +32,17 @@ public:
             MULaw = 0x7,
             DVIADPCM = 0x11
         };
-        uint16_t AudioFormat{};
+        uint16_t AudioFormat;
 
-        uint16_t NumChannels{};
-        uint32_t SampleRate{};
-        uint32_t ByteRate{};
-        uint16_t BlockAlign{};
-        uint16_t BitsPerSample{};
+        uint16_t NumChannels;
+        uint32_t SampleRate;
+        uint32_t ByteRate;
+        uint16_t BlockAlign;
+        uint16_t BitsPerSample;
 
         // data subchunk
-        uint32_t Subchunk2ID{};
-        uint32_t Subchunk2Size{};
+        uint32_t Subchunk2ID;
+        uint32_t Subchunk2Size;
     };
 
     const WavHeader &header() { return m_header; }
@@ -58,7 +58,7 @@ private:
 
     uint32_t m_size = 0;
     uint32_t m_type = 0;
-    WavHeader m_header;
+    WavHeader m_header{};
     std::vector<uint8_t> m_data;
 };
 

--- a/src/file/Compressor.cpp
+++ b/src/file/Compressor.cpp
@@ -116,7 +116,7 @@ void Compressor::startCompression(void)
 {
     try {
         // Important thing here is window_bits = 15
-        bufferedStream_ = std::make_shared<zstr::ostream>(*ostream_, (std::size_t)1 << 20, false, -15);
+        bufferedStream_ = std::make_shared<zstr::ostream>(*ostream_, (std::size_t)1 << 20, Z_DEFAULT_COMPRESSION, -15);
     } catch (const zstr::Exception &exception) {
         bufferedStream_.reset();
         std::cerr << "Zlib compression failed with error code: "

--- a/src/file/lzx.c
+++ b/src/file/lzx.c
@@ -537,6 +537,10 @@ int LZXdecompress(struct LZXstate *pState, unsigned char *inpos, unsigned char *
                     BUILD_TABLE(ALIGNED);
                     /* rest of aligned header is same as verbatim */
 
+#ifdef __GNUC__
+                    // Can't get the magic fallthrough comment stuff to work
+                    __attribute__ ((fallthrough));
+#endif
                 case LZX_BLOCKTYPE_VERBATIM:
                     READ_LENGTHS(MAINTREE, 0, 256);
                     READ_LENGTHS(MAINTREE, 256, pState->main_elements);

--- a/src/resource/SmpFile.cpp
+++ b/src/resource/SmpFile.cpp
@@ -13,18 +13,16 @@ void SmpFile::serializeObject()
         return;
     }
 
-
-    serialize(m_version2);
-    serialize(m_numFrames);
-    serialize(m_size);
-    serialize(m_unknown);
-    serialize(m_numFrames2);
-    serialize(m_checksum);
-    serialize(m_byteCount);
     serialize(m_version);
+    serialize(m_numFrames);
+    serialize(m_facetNum);
+    serialize(m_framesPerFacet);
+    serialize(m_checksum);
+    serialize(m_size);
+    serialize(m_source_format);
     serialize(m_comment, 32);
 
-    log.warn("ver % frames % size % source % comment %", m_version, m_numFrames, m_size, m_byteCount, m_comment);
+    log.warn("ver % frames % size % comment %", m_version, m_numFrames, m_size, m_comment);
 
     serialize(m_frames, m_numFrames);
 }

--- a/src/resource/SmxFrame.cpp
+++ b/src/resource/SmxFrame.cpp
@@ -75,11 +75,11 @@ void SmxFrame::readNormalGraphics()
     uint32_t pixelDataSize = 0;
     serialize(pixelDataSize);
 
-    std::vector<uint8_t> commands(commandsSize);
-    getIStream()->read(reinterpret_cast<char*>(commands.data()), commandsSize);
+    std::vector<uint8_t> commands;
+    serialize(commands, commandsSize);
 
-    std::vector<uint8_t> pixelData(pixelDataSize);
-    getIStream()->read(reinterpret_cast<char*>(pixelData.data()), pixelDataSize);
+    std::vector<uint8_t> pixelData;
+    serialize(pixelData, pixelDataSize);
 
     const std::vector<SmpPixel> pixelsVector = m_bundleHeader.type & BundleHeader::HasDamageMask ?
                 decode8To5(std::move(pixelData)) :


### PR DESCRIPTION
Heyho,

I fixed a few errors in your implementation. Also, we updated the docs a bit since almost all fields are confirmed now. The damage *modifier* (formerly damage mask) has been recovered from the game. Also "bundle" is now called "frame" and what was "frame" is now "layer". The changes I made should integrate that into your code base.

:tada: 