### PR TITLE
build: fix using bundled miniz

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if (WIN32)
     set(ICONV_LIBRARIES)
 endif()
 
-set(DAT_SRC
+set(DAT_SRC ${DAT_SRC}
     src/dat/Research.cpp 
    
     src/dat/Civ.cpp


### PR DESCRIPTION
the `miniz.c` file was added to the `DAT_SRC` list _before_ this line,
so it would get overridden and discarded. That would cause linking
errors down the line.

Now it concats the source file list and all should be good!